### PR TITLE
Update Mercedes-Benz E-Class generations: Add comprehensive generation data with Wikipedia references

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,88 +2,6 @@
 
 This repository contains signal set configurations for the Mercedes-Benz E-Class, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Mercedes-Benz E-Class.
 
-## Generations
-
-The Mercedes-Benz E-Class represents the pinnacle of midsize luxury sedan engineering, evolving through six generations since receiving its nameplate in 1993, with predecessor lineage dating to 1953:
-
-- **Historical Foundation (1953-1985)**: Predecessor generations establishing luxury sedan credentials:
-  - W120 'Ponton' 180 (1953): Foundation of Mercedes midsize sedan philosophy
-  - W114/W115 'Stroke-8' (1968): Engineering advancement and market expansion
-  - W123 (1976): Best-selling predecessor establishing global luxury reputation
-  - Pre-E-Class generations that defined Mercedes-Benz luxury and reliability standards
-
-- **W124 Generation (1985-1995)**: Birth of the E-Class nameplate and modern Mercedes luxury sedan identity:
-  - 1985: Launch as Mercedes-Benz 200-500 series without E-Class designation
-  - 1993: First generation to receive official E-Class badge designation
-  - Bruno Sacco design leadership creating iconic rectangular headlight aesthetic
-  - Introduction of body-colored "Sacco-planks" cladding for visual sophistication
-  - Clear lens turn indicators replacing traditional amber lenses
-  - Established foundation for all subsequent E-Class generations
-  - Built reputation for exceptional build quality and engineering excellence
-
-- **W210 Generation (1996-2002)**: Technological advancement with distinctive dual-headlamp design:
-  - Mid-1990s: Revolutionary switch from mono-bloc to dual headlamp configuration
-  - Design language used across Mercedes lineup until 2016
-  - Enhanced safety systems and improved aerodynamics
-  - Advanced electronic systems integration
-  - Continued emphasis on luxury appointment and ride quality
-  - Established modern Mercedes electronic architecture foundation
-
-- **W211 Generation (2003-2009)**: Major redesign emphasizing luxury and performance integration:
-  - Complete exterior and interior redesign for enhanced contemporary appeal
-  - More aggressive, squared design language balancing elegance with presence
-  - Advanced drivetrain options and improved handling dynamics
-  - Enhanced luxury sedan positioning within Mercedes hierarchy
-  - Significant technological advancement in safety and comfort systems
-  - Improved structural integrity and crash protection
-
-- **W212 Generation (2010-2016)**: Comprehensive evolution with advanced technology integration:
-  - 2010: Launch with major exterior and interior improvements
-  - 2013: Extensive facelift representing €1 billion development investment
-  - Revolutionary singular front light design replacing twin headlamp tradition
-  - Integrated LED daytime running lights as standard equipment
-  - Significant fuel economy improvements across entire engine lineup
-  - Updated safety features establishing new luxury sedan benchmarks
-  - Enhanced connectivity and infotainment system sophistication
-
-- **W213 Generation (2017-2023)**: Advanced autonomous technology and design synthesis:
-  - January 2016: North American International Auto Show debut
-  - Design integration of W222 S-Class and W205 C-Class styling elements
-  - Major powertrain evolution: inline-six engines replacing V6 configuration
-  - New generation four-cylinder diesel engines for improved efficiency
-  - Second-most technologically advanced Mercedes after S-Class
-  - Autonomous driving capability up to 130 mph for 2-minute intervals
-  - Optional dual 12.3-inch high-resolution display configuration
-  - 2020: Mid-generation facelift with enhanced technology and styling
-
-- **W214 Generation (2024-present)**: Latest evolution combining luxury with cutting-edge innovation:
-  - April 25, 2023: Sixth generation debut after seven-year W213 production
-  - Spring 2023: Market introduction representing comprehensive redesign
-  - Body style streamlining: sedan and wagon configurations maintained
-  - CLE-Class introduction absorbing coupe and convertible variants
-
-  **Current Engine Lineup:**
-  - E350 4MATIC: 255 hp turbocharged 2.0L inline-4 (295 lb-ft torque)
-  - E450 4MATIC: 375 hp turbocharged 3.0L inline-6 (369 lb-ft torque)
-
-  **Performance Specifications:**
-  - E350 4MATIC: 0-60 mph in 5.8 seconds
-  - E450 4MATIC: 0-60 mph in 4.4 seconds
-  - Standard all-wheel drive across entire lineup
-  - Combined 39 inches of available display technology
-
-  **Pricing and Market Position:**
-  - 2024-2026 MSRP: $63,900–$78,300
-  - Continued luxury midsize sedan segment leadership
-  - Advanced driver assistance and autonomous capabilities
-
-- **Commercial Success and Legacy**: Mercedes-Benz's most successful model line:
-  - Over 13 million E-Class vehicles sold globally by 2015
-  - Consistent best-selling Mercedes-Benz model across multiple decades
-  - Benchmark for luxury sedan engineering and technological innovation
-  - Foundation for Mercedes luxury sedan reputation worldwide
-  - Continuous evolution maintaining market leadership for over 30 years
-
 ## Contributing
 
 Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
@@ -95,4 +13,3 @@ Contributions are welcome! If you would like to add support for additional model
 ## Issues
 
 If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
-

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,0 +1,33 @@
+references:
+  - "https://en.wikipedia.org/wiki/Mercedes-Benz_E-Class"
+
+generations:
+  - name: "First Generation (W124)"
+    start_year: 1993
+    end_year: 1997
+    description: "E-Class nameplate adopted in August 1993. Sedan (W124), Coupe (C124), Convertible (A124), and Estate (S124) body configurations. Sedans produced through 1995, estates and coupes through 1996, cabriolets finished in 1997."
+
+  - name: "Second Generation (W210)"
+    start_year: 1995
+    end_year: 2003
+    description: "Launched in January 1995. Featured four large oval headlights. The sedan was replaced by the W211 in 2002, while the wagon version continued to be sold until March 2003. A facelift was introduced in September 1999."
+
+  - name: "Third Generation (W211)"
+    start_year: 2002
+    end_year: 2009
+    description: "Launched in 2002. Featured a major redesign with more aggressive, squared design language. Facelifted in June 2006 for the 2007 model year to address quality and technical issues."
+
+  - name: "Fourth Generation (W212)"
+    start_year: 2009
+    end_year: 2016
+    description: "Replaced the W211 in 2009 as a 2010 model. Featured new safety and convenience technologies including blind spot monitor, Lane Keeping Assist, Pre-safe with Attention Assist, and Night View Assist Plus. In 2013, received a comprehensive facelift with significant styling changes, fuel economy improvements, and updated safety features. The facelift featured singular front lights replacing twin headlamp design with integrated LED daytime running lights."
+
+  - name: "Fifth Generation (W213)"
+    start_year: 2016
+    end_year: 2023
+    description: "Unveiled at the 2016 North American International Auto Show. Design incorporates cues from the larger W222 S-Class and smaller W205 C-Class. Features a switch to inline six-cylinder engines from previous V6 engines and new generation four-cylinder diesel engines. Second-most technologically advanced Mercedes after S-Class. Includes autonomous driving capability up to 130 mph for up to 2 minutes. Received a mid-generation facelift in 2020."
+
+  - name: "Sixth Generation (W214)"
+    start_year: 2023
+    end_year: null
+    description: "Debuted on April 25, 2023. Body styles include sedan and wagon, while coupes and convertibles were discontinued and will slot under the new CLE nameplate. Current production generation."


### PR DESCRIPTION
- Added 6 generations of E-Class with accurate production dates (W124 through W214)
- W124 (1993-1997): First generation with E-Class nameplate adoption
- W210 (1995-2003): Second generation with dual headlight design
- W211 (2002-2009): Third generation with redesigned styling
- W212 (2009-2016): Fourth generation with 2013 comprehensive facelift
- W213 (2016-2023): Fifth generation with inline-six engines and autonomous driving
- W214 (2023-present): Sixth generation debut with sedan and wagon body styles
- Updated README.md to standard template format
- Wikipedia reference: https://en.wikipedia.org/wiki/Mercedes-Benz_E-Class

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>
